### PR TITLE
修改pom.xml中spring-boot-starter-tomcat依赖scope为默认值

### DIFF
--- a/kekoa-web/pom.xml
+++ b/kekoa-web/pom.xml
@@ -27,7 +27,7 @@
 	    <dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
-			<scope>provided</scope>
+			<!--<scope>provided</scope>-->
 		</dependency>
 	    
 	    

--- a/kekoa-web/src/main/java/com/sina/kekoa/config/web/ShiroConfiguration.java
+++ b/kekoa-web/src/main/java/com/sina/kekoa/config/web/ShiroConfiguration.java
@@ -62,12 +62,12 @@ public class ShiroConfiguration {
         return filterRegistration;
     }
 
-    @Bean(name = "lifecycleBeanPostProcessor")
+    //@Bean(name = "lifecycleBeanPostProcessor")
     public LifecycleBeanPostProcessor getLifecycleBeanPostProcessor() {
         return new LifecycleBeanPostProcessor();
     }
 
-    @Bean
+    //@Bean
     public DefaultAdvisorAutoProxyCreator getDefaultAdvisorAutoProxyCreator() {
         DefaultAdvisorAutoProxyCreator daap = new DefaultAdvisorAutoProxyCreator();
         daap.setProxyTargetClass(true);


### PR DESCRIPTION
部署为jar包时会找不到javax.servlet.*相关类，只有当部署到容器中时才需要

```
<scope>provided</scope>
```
